### PR TITLE
feat: deploy to staging on merge to develop

### DIFF
--- a/.github/workflows/deploy-staging-digdir.yaml
+++ b/.github/workflows/deploy-staging-digdir.yaml
@@ -1,9 +1,9 @@
 name: Build and deploy to staging (digdir) when pull request is created
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - develop
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,9 +1,9 @@
 name: Build and deploy to staging when pull request is created
 
 on:
-  pull_request:
+  push:
     branches:
-      - master
+      - develop
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Mtp høy kollisjonsfare for pull requester i dette repoet kan vi prøve en annen deploy-prosess her, dette burde fungere som en midlertidig løsning for usikkerhet rundt hva som er deployet til it1.

Merge til develop -> deploy til it1/staging
Merge/cherry-pick av develop inn i master -> deploy til prod og demo