### PR TITLE
Fix/ois/details page

### DIFF
--- a/src/components/dataset-details-page/index.tsx
+++ b/src/components/dataset-details-page/index.tsx
@@ -80,7 +80,7 @@ const DatasetDetailsPage: FC<Props> = ({
     return () => {
       resetDataset();
     };
-  }, []);
+  }, [datasetId]);
 
   const conceptIdentifiers = dataset?.subject?.map(
     ({ identifier }) => identifier


### PR DESCRIPTION
Skal rette feil at redux store ikke oppdateres med nytt datasett hvis man navigerer fra et datasett til et annet datasett, f.eks. via en relasjon.