### PR TITLE
fix(data-service-details-page): fix servicetype code mapping

### DIFF
--- a/src/pages/data-service-details-page/data-service-details-page.jsx
+++ b/src/pages/data-service-details-page/data-service-details-page.jsx
@@ -354,12 +354,17 @@ const renderServiceType = (conformsTo, referenceData) => {
     return null;
   }
 
+  const serviceTypeCodeMapping = {
+    CUSTOMER_RELATIONS: 'Kundeforhold',
+    ACCOUNT_DETAILS: 'Kontoopplysninger'
+  };
+
   const children = items =>
     items.map(({ uri }) => {
       const referenceDataServiceTypeItem = getReferenceDataByCode(
         referenceData,
         REFERENCEDATA_PATH_APISERVICETYPE,
-        uri.substring(uri.lastIndexOf('#') + 1)
+        serviceTypeCodeMapping[uri.substring(uri.lastIndexOf('#') + 1)]
       );
 
       return (


### PR DESCRIPTION
Har denne mapping i dataservice-catalog-gui:
export enum ServiceType {
  CUSTOMER_RELATIONS = 'CUSTOMER_RELATIONS',
  ACCOUNT_DETAILS = 'ACCOUNT_DETAILS'
}

og mapper det om til code som brukes i referansedata (https://staging.fellesdatakatalog.digdir.no/reference-data/codes/apiservicetype):

const serviceTypeCodeMapping = {
    CUSTOMER_RELATIONS: 'Kundeforhold',
    ACCOUNT_DETAILS: 'Kontoopplysninger'
  };