### PR TITLE
fix: prevent infinite loop of requests to fetch concepts

### DIFF
--- a/src/components/infomodel-structure/model-element-list/index.tsx
+++ b/src/components/infomodel-structure/model-element-list/index.tsx
@@ -22,9 +22,9 @@ const ModelElementList: FC<Props> = ({ title, properties, modelElements }) =>
   properties && properties.length > 0 ? (
     <>
       <ListTitleSC.ListTitle>{title}</ListTitleSC.ListTitle>
-      {properties.map(property => (
+      {properties.map((property, index) => (
         <Element
-          key={property.identifier}
+          key={property.identifier ?? property.uri ?? `property-${index}`}
           property={property}
           code={property}
           modelElements={modelElements}

--- a/src/components/information-model-details-page/index.tsx
+++ b/src/components/information-model-details-page/index.tsx
@@ -155,7 +155,7 @@ const InformationModelDetailsPage: FC<Props> = ({
         identifiers: conceptIdentifiers as string[]
       });
     }
-  }, [conceptIdentifiers]);
+  }, [conceptIdentifiers.join()]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/types/domain.d.ts
+++ b/src/types/domain.d.ts
@@ -49,6 +49,7 @@ export interface InformationModel {
 }
 
 export interface ModelCodeElement {
+  uri: string;
   identifier: string;
   prefLabel: Partial<TextLanguage> | null;
   inScheme: string[] | null;


### PR DESCRIPTION
Det ble generert en ny array med conceptReferences hver render. Ny object referanse => ny render. Så løsningen er å joine den å gjøre den om til string. 