### PR TITLE
prodsetting portal

### DIFF
--- a/src/api/search-fulltext-api/datasets.ts
+++ b/src/api/search-fulltext-api/datasets.ts
@@ -25,7 +25,8 @@ const mapFilters = ({
   last_x_days,
   format,
   subjectExists,
-  catalog_name
+  catalog_name,
+  keywords
 }: any) => {
   const filters = [];
   if (id) {
@@ -91,6 +92,9 @@ const mapFilters = ({
     filters.push({
       catalog_name
     });
+  }
+  if (keywords) {
+    filters.push({ keywords });
   }
 
   // Filter out NAP data if filterTransportDatasets in conf is true

--- a/src/api/search-fulltext-api/informationmodels.ts
+++ b/src/api/search-fulltext-api/informationmodels.ts
@@ -14,7 +14,8 @@ const mapFilters = ({
   losTheme: los,
   orgPath,
   conceptIdentifiers,
-  last_x_days
+  last_x_days,
+  keywords
 }: any) => {
   const filters = [];
 
@@ -28,6 +29,10 @@ const mapFilters = ({
 
   if (orgPath) {
     filters.push({ orgPath });
+  }
+
+  if (keywords) {
+    filters.push({ keywords });
   }
 
   if (conceptIdentifiers) {

--- a/src/components/details-page/components/details-page/index.tsx
+++ b/src/components/details-page/components/details-page/index.tsx
@@ -142,7 +142,7 @@ const DetailsPage: FC<PropsWithChildren<Props>> = ({
     [Entity.DATASET]: translations.detailsPage.owner,
     [Entity.DATA_SERVICE]: translations.detailsPage.provider,
     [Entity.CONCEPT]: translations.detailsPage.responsible,
-    [Entity.INFORMATION_MODEL]: translations.detailsPage.owner,
+    [Entity.INFORMATION_MODEL]: translations.detailsPage.responsible,
     [Entity.PUBLIC_SERVICE]: translations.detailsPage.provider
   };
 

--- a/src/components/infomodel-structure/__tests__/__snapshots__/infomodel-structure.component.test.tsx.snap
+++ b/src/components/infomodel-structure/__tests__/__snapshots__/infomodel-structure.component.test.tsx.snap
@@ -35,10 +35,12 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse"
               realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -426,6 +428,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -813,6 +816,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -1228,10 +1232,39 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse"
               realization={null}
+              specialization={
+                Object {
+                  "belongsToModule": "Adresse",
+                  "codeListReference": null,
+                  "codes": null,
+                  "description": null,
+                  "elementTypes": Array [
+                    "http://www.w3.org/2002/07/owl#NamedIndividual",
+                    "https://data.norge.no/vocabulary/modelldcatno#ObjectType",
+                  ],
+                  "fractionDigits": null,
+                  "hasProperty": null,
+                  "identifier": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse",
+                  "length": null,
+                  "maxInclusive": null,
+                  "maxLength": null,
+                  "minInclusive": null,
+                  "minLength": null,
+                  "pattern": null,
+                  "subject": null,
+                  "title": Object {
+                    "nb": "Adresse",
+                  },
+                  "totalDigits": null,
+                  "typeDefinitionReference": null,
+                  "uri": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse",
+                }
+              }
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -1619,6 +1652,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -2006,6 +2040,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -2421,10 +2456,41 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Matrikkeladresse"
               realization={null}
+              specialization={
+                Object {
+                  "belongsToModule": "Adresse",
+                  "codeListReference": null,
+                  "codes": null,
+                  "description": null,
+                  "elementTypes": Array [
+                    "http://www.w3.org/2002/07/owl#NamedIndividual",
+                    "https://data.norge.no/vocabulary/modelldcatno#ObjectType",
+                  ],
+                  "fractionDigits": null,
+                  "hasProperty": Array [
+                    "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#geografiskAdresseSpesialiserer",
+                  ],
+                  "identifier": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                  "length": null,
+                  "maxInclusive": null,
+                  "maxLength": null,
+                  "minInclusive": null,
+                  "minLength": null,
+                  "pattern": null,
+                  "subject": null,
+                  "title": Object {
+                    "nb": "GeografiskAdresse",
+                  },
+                  "totalDigits": null,
+                  "typeDefinitionReference": null,
+                  "uri": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                }
+              }
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -2943,6 +3009,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -3330,6 +3397,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -3745,10 +3813,41 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#OffisiellAdresse"
               realization={null}
+              specialization={
+                Object {
+                  "belongsToModule": "Adresse",
+                  "codeListReference": null,
+                  "codes": null,
+                  "description": null,
+                  "elementTypes": Array [
+                    "http://www.w3.org/2002/07/owl#NamedIndividual",
+                    "https://data.norge.no/vocabulary/modelldcatno#ObjectType",
+                  ],
+                  "fractionDigits": null,
+                  "hasProperty": Array [
+                    "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#geografiskAdresseSpesialiserer",
+                  ],
+                  "identifier": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                  "length": null,
+                  "maxInclusive": null,
+                  "maxLength": null,
+                  "minInclusive": null,
+                  "minLength": null,
+                  "pattern": null,
+                  "subject": null,
+                  "title": Object {
+                    "nb": "GeografiskAdresse",
+                  },
+                  "totalDigits": null,
+                  "typeDefinitionReference": null,
+                  "uri": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                }
+              }
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -4203,6 +4302,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -4590,6 +4690,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -5005,10 +5106,41 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Postboksadresse"
               realization={null}
+              specialization={
+                Object {
+                  "belongsToModule": "Adresse",
+                  "codeListReference": null,
+                  "codes": null,
+                  "description": null,
+                  "elementTypes": Array [
+                    "http://www.w3.org/2002/07/owl#NamedIndividual",
+                    "https://data.norge.no/vocabulary/modelldcatno#ObjectType",
+                  ],
+                  "fractionDigits": null,
+                  "hasProperty": Array [
+                    "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#geografiskAdresseSpesialiserer",
+                  ],
+                  "identifier": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                  "length": null,
+                  "maxInclusive": null,
+                  "maxLength": null,
+                  "minInclusive": null,
+                  "minLength": null,
+                  "pattern": null,
+                  "subject": null,
+                  "title": Object {
+                    "nb": "GeografiskAdresse",
+                  },
+                  "totalDigits": null,
+                  "typeDefinitionReference": null,
+                  "uri": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                }
+              }
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -5495,6 +5627,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -5882,6 +6015,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -6297,10 +6431,41 @@ exports[`InfoModelStructure component should render with props 1`] = `
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Vegadresse"
               realization={null}
+              specialization={
+                Object {
+                  "belongsToModule": "Adresse",
+                  "codeListReference": null,
+                  "codes": null,
+                  "description": null,
+                  "elementTypes": Array [
+                    "http://www.w3.org/2002/07/owl#NamedIndividual",
+                    "https://data.norge.no/vocabulary/modelldcatno#ObjectType",
+                  ],
+                  "fractionDigits": null,
+                  "hasProperty": Array [
+                    "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#geografiskAdresseSpesialiserer",
+                  ],
+                  "identifier": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                  "length": null,
+                  "maxInclusive": null,
+                  "maxLength": null,
+                  "minInclusive": null,
+                  "minLength": null,
+                  "pattern": null,
+                  "subject": null,
+                  "title": Object {
+                    "nb": "GeografiskAdresse",
+                  },
+                  "totalDigits": null,
+                  "typeDefinitionReference": null,
+                  "uri": "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#GeografiskAdresse",
+                }
+              }
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -6915,6 +7080,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Attribute"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -7302,6 +7468,7 @@ exports[`InfoModelStructure component should render with props 1`] = `
           title="Association"
         />
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -7717,9 +7884,12 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Kommunenummer"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
@@ -7763,13 +7933,17 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adressenummer"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -8247,13 +8421,17 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Matrikkelnummer"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -8827,13 +9005,17 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Punkt"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -9311,13 +9493,17 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Poststed"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
         <Memo(ModelElementList)
+          concepts={Object {}}
           modelElements={
             Object {
               "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Adresse": Object {
@@ -9800,9 +9986,12 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Tekst"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>
@@ -9850,9 +10039,12 @@ exports[`InfoModelStructure component should render with props 1`] = `
         >
           <Memo(ExpansionPanelBody)>
             <Component
+              abstraction={null}
               belongsToModule={null}
               description={null}
               identifier="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Heltall"
+              realization={null}
+              specialization={null}
             />
           </Memo(ExpansionPanelBody)>
         </Styled(Component)>

--- a/src/components/infomodel-structure/infomodel-structure.component.tsx
+++ b/src/components/infomodel-structure/infomodel-structure.component.tsx
@@ -117,6 +117,21 @@ export const InfoModelStructure: FC<Props> = ({
     return isRealizationOf ? modelElements[isRealizationOf] : null;
   };
 
+  const unwrapSpecialization = (properties?: string[] | null) => {
+    const isSpecializationOf = (
+      properties
+        ?.map(property => modelProperties[property])
+        .filter(({ propertyTypes }) =>
+          propertyTypes?.some(type =>
+            type.split('#').includes('Specialization')
+          )
+        )
+        .filter(Boolean) ?? []
+    ).shift()?.hasGeneralConcept;
+
+    return isSpecializationOf ? modelElements[isSpecializationOf] : null;
+  };
+
   const conceptMap = concepts.reduce<Record<string, Concept>>(
     (previous, current) => ({ ...previous, [current.identifier]: current }),
     {}
@@ -145,7 +160,13 @@ export const InfoModelStructure: FC<Props> = ({
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
-                  {(identifier || description || belongsToModule) && (
+                  {(identifier ||
+                    description ||
+                    belongsToModule ||
+                    (subject && conceptMap[subject]) ||
+                    unwrapAbstraction(hasProperty) ||
+                    unwrapRealization(hasProperty) ||
+                    unwrapSpecialization(hasProperty)) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -161,6 +182,7 @@ export const InfoModelStructure: FC<Props> = ({
                           concept={subject ? conceptMap[subject] : undefined}
                           abstraction={unwrapAbstraction(hasProperty)}
                           realization={unwrapRealization(hasProperty)}
+                          specialization={unwrapSpecialization(hasProperty)}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>
@@ -215,7 +237,10 @@ export const InfoModelStructure: FC<Props> = ({
                   {(identifier ||
                     description ||
                     belongsToModule ||
-                    (subject && conceptMap[subject])) && (
+                    (subject && conceptMap[subject]) ||
+                    unwrapAbstraction(hasProperty) ||
+                    unwrapRealization(hasProperty) ||
+                    unwrapSpecialization(hasProperty)) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -231,6 +256,7 @@ export const InfoModelStructure: FC<Props> = ({
                           concept={subject ? conceptMap[subject] : undefined}
                           abstraction={unwrapAbstraction(hasProperty)}
                           realization={unwrapRealization(hasProperty)}
+                          specialization={unwrapSpecialization(hasProperty)}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>
@@ -275,7 +301,8 @@ export const InfoModelStructure: FC<Props> = ({
               belongsToModule,
               codeListReference,
               codes,
-              subject
+              subject,
+              hasProperty
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
@@ -286,7 +313,10 @@ export const InfoModelStructure: FC<Props> = ({
                   {(identifier ||
                     description ||
                     belongsToModule ||
-                    (subject && conceptMap[subject])) && (
+                    (subject && conceptMap[subject]) ||
+                    unwrapAbstraction(hasProperty) ||
+                    unwrapRealization(hasProperty) ||
+                    unwrapSpecialization(hasProperty)) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -300,6 +330,9 @@ export const InfoModelStructure: FC<Props> = ({
                           identifier={identifier}
                           description={description}
                           concept={subject ? conceptMap[subject] : undefined}
+                          abstraction={unwrapAbstraction(hasProperty)}
+                          realization={unwrapRealization(hasProperty)}
+                          specialization={unwrapSpecialization(hasProperty)}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>
@@ -356,7 +389,10 @@ export const InfoModelStructure: FC<Props> = ({
                   {(identifier ||
                     description ||
                     belongsToModule ||
-                    (subject && conceptMap[subject])) && (
+                    (subject && conceptMap[subject]) ||
+                    unwrapAbstraction(hasProperty) ||
+                    unwrapRealization(hasProperty) ||
+                    unwrapSpecialization(hasProperty)) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -370,6 +406,9 @@ export const InfoModelStructure: FC<Props> = ({
                           identifier={identifier}
                           description={description}
                           concept={subject ? conceptMap[subject] : undefined}
+                          abstraction={unwrapAbstraction(hasProperty)}
+                          realization={unwrapRealization(hasProperty)}
+                          specialization={unwrapSpecialization(hasProperty)}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>
@@ -407,7 +446,8 @@ export const InfoModelStructure: FC<Props> = ({
               maxInclusive,
               pattern,
               totalDigits,
-              subject
+              subject,
+              hasProperty
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
@@ -418,7 +458,10 @@ export const InfoModelStructure: FC<Props> = ({
                   {(identifier ||
                     description ||
                     belongsToModule ||
-                    (subject && conceptMap[subject])) && (
+                    (subject && conceptMap[subject]) ||
+                    unwrapAbstraction(hasProperty) ||
+                    unwrapRealization(hasProperty) ||
+                    unwrapSpecialization(hasProperty)) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -432,6 +475,9 @@ export const InfoModelStructure: FC<Props> = ({
                           identifier={identifier}
                           description={description}
                           concept={subject ? conceptMap[subject] : undefined}
+                          abstraction={unwrapAbstraction(hasProperty)}
+                          realization={unwrapRealization(hasProperty)}
+                          specialization={unwrapSpecialization(hasProperty)}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>

--- a/src/components/infomodel-structure/infomodel-structure.component.tsx
+++ b/src/components/infomodel-structure/infomodel-structure.component.tsx
@@ -170,16 +170,19 @@ export const InfoModelStructure: FC<Props> = ({
                     title={translations.infoMod.structure.attribute}
                     properties={unwrapAttributes(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                   <ModelElementList
                     title={translations.infoMod.structure.association}
                     properties={unwrapAssociations(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                   <ModelElementList
                     title={translations.infoMod.structure.role}
                     properties={unwrapRoles(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                 </ExpansionPanelBody>
               </SC.ObjectTypeExpansionPanel>
@@ -209,7 +212,10 @@ export const InfoModelStructure: FC<Props> = ({
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
-                  {(identifier || description || belongsToModule) && (
+                  {(identifier ||
+                    description ||
+                    belongsToModule ||
+                    (subject && conceptMap[subject])) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -234,16 +240,19 @@ export const InfoModelStructure: FC<Props> = ({
                     title={translations.infoMod.structure.attribute}
                     properties={unwrapAttributes(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                   <ModelElementList
                     title={translations.infoMod.structure.association}
                     properties={unwrapAssociations(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                   <ModelElementList
                     title={translations.infoMod.structure.role}
                     properties={unwrapRoles(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                 </ExpansionPanelBody>
               </SC.ObjectTypeExpansionPanel>
@@ -265,7 +274,8 @@ export const InfoModelStructure: FC<Props> = ({
               description,
               belongsToModule,
               codeListReference,
-              codes
+              codes,
+              subject
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
@@ -273,7 +283,10 @@ export const InfoModelStructure: FC<Props> = ({
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
-                  {(identifier || description || belongsToModule) && (
+                  {(identifier ||
+                    description ||
+                    belongsToModule ||
+                    (subject && conceptMap[subject])) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -286,6 +299,7 @@ export const InfoModelStructure: FC<Props> = ({
                         <Description
                           identifier={identifier}
                           description={description}
+                          concept={subject ? conceptMap[subject] : undefined}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>
@@ -296,6 +310,7 @@ export const InfoModelStructure: FC<Props> = ({
                       title={translations.infoMod.structure.code}
                       properties={codes}
                       modelElements={modelElements}
+                      concepts={conceptMap}
                     />
                   )}
                   {codeListReference && (
@@ -338,7 +353,10 @@ export const InfoModelStructure: FC<Props> = ({
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
-                  {(identifier || description || belongsToModule) && (
+                  {(identifier ||
+                    description ||
+                    belongsToModule ||
+                    (subject && conceptMap[subject])) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -361,6 +379,7 @@ export const InfoModelStructure: FC<Props> = ({
                     title={translations.infoMod.structure.attribute}
                     properties={unwrapAttributes(hasProperty)}
                     modelElements={modelElements}
+                    concepts={conceptMap}
                   />
                 </ExpansionPanelBody>
               </SC.ObjectTypeExpansionPanel>
@@ -387,7 +406,8 @@ export const InfoModelStructure: FC<Props> = ({
               minInclusive,
               maxInclusive,
               pattern,
-              totalDigits
+              totalDigits,
+              subject
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
@@ -395,7 +415,10 @@ export const InfoModelStructure: FC<Props> = ({
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
-                  {(identifier || description || belongsToModule) && (
+                  {(identifier ||
+                    description ||
+                    belongsToModule ||
+                    (subject && conceptMap[subject])) && (
                     <SC.ObjectTypeExpansionPanel
                       showWithoutHeadAndPadding
                       shouldExpandOnHeadClick={false}
@@ -408,6 +431,7 @@ export const InfoModelStructure: FC<Props> = ({
                         <Description
                           identifier={identifier}
                           description={description}
+                          concept={subject ? conceptMap[subject] : undefined}
                           belongsToModule={belongsToModule}
                         />
                       </ExpansionPanelBody>

--- a/src/components/infomodel-structure/infomodel-structure.component.tsx
+++ b/src/components/infomodel-structure/infomodel-structure.component.tsx
@@ -156,7 +156,7 @@ export const InfoModelStructure: FC<Props> = ({
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
-                id={identifier}
+                id={uri ?? identifier ?? ''}
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
@@ -230,7 +230,7 @@ export const InfoModelStructure: FC<Props> = ({
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
-                id={identifier}
+                id={uri ?? identifier ?? ''}
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
@@ -306,7 +306,7 @@ export const InfoModelStructure: FC<Props> = ({
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
-                id={identifier}
+                id={uri ?? identifier ?? ''}
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
@@ -382,7 +382,7 @@ export const InfoModelStructure: FC<Props> = ({
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
-                id={identifier}
+                id={uri ?? identifier ?? ''}
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>
@@ -451,7 +451,7 @@ export const InfoModelStructure: FC<Props> = ({
             }) => (
               <SC.ObjectTypeExpansionPanel
                 key={`${identifier}-${uri}`}
-                id={identifier}
+                id={uri ?? identifier ?? ''}
               >
                 <ExpansionPanelHead>{translate(title)}</ExpansionPanelHead>
                 <ExpansionPanelBody>

--- a/src/components/infomodel-structure/model-description/model-description.component.tsx
+++ b/src/components/infomodel-structure/model-description/model-description.component.tsx
@@ -22,6 +22,7 @@ interface Props {
   concept?: Partial<Concept>;
   abstraction?: Partial<InformationModelElement> | null;
   realization?: Partial<InformationModelElement> | null;
+  specialization?: Partial<InformationModelElement> | null;
 }
 
 type ScollLinkType = FC<
@@ -37,7 +38,8 @@ export const Description: FC<Props> = ({
   concept: { id, prefLabel, definition, publisher, uri } = {},
   belongsToModule,
   abstraction,
-  realization
+  realization,
+  specialization
 }) => (
   <SC.ModelDescription>
     {description && (
@@ -130,6 +132,25 @@ export const Description: FC<Props> = ({
           as={Scroll.Link}
         >
           {translate(realization.title)}
+        </ScollLink>
+      </SC.DescriptionField>
+    )}
+
+    {specialization && (
+      <SC.DescriptionField>
+        <strong>
+          {localization.infoMod.modelDescription.specializationOf}:
+        </strong>
+        <ScollLink
+          to={specialization.identifier ?? specialization.uri ?? ''}
+          spy
+          smooth
+          isDynamic
+          offset={0}
+          duration={1500}
+          as={Scroll.Link}
+        >
+          {translate(specialization.title)}
         </ScollLink>
       </SC.DescriptionField>
     )}

--- a/src/components/infomodel-structure/model-element-list/element/index.tsx
+++ b/src/components/infomodel-structure/model-element-list/element/index.tsx
@@ -92,7 +92,7 @@ const Element: FC<Props> = ({ property, code, modelElements, concepts }) => {
         <span>
           {type && (
             <ScollLink
-              to={type.identifier ?? type.uri ?? ''}
+              to={type.uri ?? type.identifier ?? ''}
               spy
               smooth
               isDynamic
@@ -106,7 +106,7 @@ const Element: FC<Props> = ({ property, code, modelElements, concepts }) => {
           {types?.map(({ identifier, uri, title }, index) => (
             <ScollLink
               key={identifier ?? uri ?? `scroll-link-${index}`}
-              to={identifier ?? uri ?? ''}
+              to={uri ?? identifier ?? ''}
               spy
               smooth
               isDynamic

--- a/src/components/infomodel-structure/model-element-list/element/index.tsx
+++ b/src/components/infomodel-structure/model-element-list/element/index.tsx
@@ -17,13 +17,15 @@ import SC from './styled';
 import type {
   InformationModelElement,
   InformationModelProperty,
-  ModelCodeElement
+  ModelCodeElement,
+  Concept
 } from '../../../../types';
 
 interface ExternalProps {
   property: Partial<InformationModelProperty>;
   code: Partial<ModelCodeElement>;
   modelElements: Record<string, Partial<InformationModelElement>>;
+  concepts: Record<string, Concept>;
 }
 
 interface Props extends ExternalProps {}
@@ -32,7 +34,7 @@ type ScollLinkType = FC<
   Omit<ComponentProps<typeof Scroll.Link>, 'as'> & ComponentProps<typeof Link>
 >;
 
-const Element: FC<Props> = ({ property, code, modelElements }) => {
+const Element: FC<Props> = ({ property, code, modelElements, concepts }) => {
   const identifier = property.identifier || code.identifier;
   const title = translate(property.title || code.prefLabel);
   const description = translate(property.description);
@@ -53,6 +55,7 @@ const Element: FC<Props> = ({ property, code, modelElements }) => {
   const notation = code.notation;
   const minOccurs = property.minOccurs;
   const maxOccurs = property.maxOccurs;
+  const subject = property.subject ?? code.subject;
 
   const ScollLink = Link as ScollLinkType;
 
@@ -119,8 +122,16 @@ const Element: FC<Props> = ({ property, code, modelElements }) => {
         <span>{renderMultiplicityRange()}</span>
       </ExpansionPanelHead>
       <ExpansionPanelBody>
-        {(identifier || description || belongsToModule) && (
-          <Description identifier={identifier} description={description} />
+        {(identifier ||
+          description ||
+          belongsToModule ||
+          (subject && concepts[subject])) && (
+          <Description
+            identifier={identifier}
+            description={description}
+            concept={subject ? concepts[subject] : undefined}
+            belongsToModule={belongsToModule}
+          />
         )}
       </ExpansionPanelBody>
     </SC.ObjectTypeElementExpansionPanel>

--- a/src/components/infomodel-structure/model-element-list/index.tsx
+++ b/src/components/infomodel-structure/model-element-list/index.tsx
@@ -7,18 +7,25 @@ import ListTitleSC from '../list-title/styled';
 import type {
   InformationModelElement,
   InformationModelProperty,
-  ModelCodeElement
+  ModelCodeElement,
+  Concept
 } from '../../../types';
 
 interface ExternalProps {
   title: string;
   properties?: Partial<InformationModelProperty | ModelCodeElement>[];
   modelElements: Record<string, Partial<InformationModelElement>>;
+  concepts: Record<string, Concept>;
 }
 
 interface Props extends ExternalProps {}
 
-const ModelElementList: FC<Props> = ({ title, properties, modelElements }) =>
+const ModelElementList: FC<Props> = ({
+  title,
+  properties,
+  modelElements,
+  concepts
+}) =>
   properties && properties.length > 0 ? (
     <>
       <ListTitleSC.ListTitle>{title}</ListTitleSC.ListTitle>
@@ -28,6 +35,7 @@ const ModelElementList: FC<Props> = ({ title, properties, modelElements }) =>
           property={property}
           code={property}
           modelElements={modelElements}
+          concepts={concepts}
         />
       ))}
     </>

--- a/src/components/information-model-details-page/index.tsx
+++ b/src/components/information-model-details-page/index.tsx
@@ -10,10 +10,7 @@ import translations from '../../lib/localization';
 import { dateStringToDate, formatDate } from '../../lib/date-utils';
 import { getTranslateText as translate } from '../../lib/translateText';
 
-import {
-  PATHNAME_INFORMATIONMODELS,
-  PATHNAME_CONCEPTS
-} from '../../constants/constants';
+import { PATHNAME_INFORMATIONMODELS } from '../../constants/constants';
 
 import { themeFDK } from '../../app/theme';
 
@@ -147,13 +144,15 @@ const InformationModelDetailsPage: FC<Props> = ({
   ];
 
   const conceptIdentifiers = Object.values(modelElements)
+    .concat(Object.values(modelProperties))
     .map(({ subject }) => subject)
     .filter(Boolean);
 
   useEffect(() => {
     if (conceptIdentifiers.length > 0) {
       getConcepts({
-        identifiers: conceptIdentifiers as string[]
+        identifiers: conceptIdentifiers as string[],
+        size: 1000
       });
     }
   }, [conceptIdentifiers.join()]);
@@ -443,32 +442,6 @@ const InformationModelDetailsPage: FC<Props> = ({
                   property={translations.infoMod.replaces}
                   value={replaces}
                 />
-              )}
-            </KeyValueList>
-          </ContentSection>
-        )}
-        {concepts.length > 0 && (
-          <ContentSection
-            id="concept-references"
-            title={
-              translations.detailsPage.sectionTitles.informationModel
-                .conceptReferences
-            }
-          >
-            <KeyValueList>
-              {concepts.map(
-                ({ id, prefLabel, definition: { text: definition } }) =>
-                  id && (
-                    <KeyValueListItem
-                      key={id}
-                      property={
-                        <Link to={`${PATHNAME_CONCEPTS}/${id}`} as={RouteLink}>
-                          {translate(prefLabel)}
-                        </Link>
-                      }
-                      value={translate(definition)}
-                    />
-                  )
               )}
             </KeyValueList>
           </ContentSection>

--- a/src/components/information-model-details-page/index.tsx
+++ b/src/components/information-model-details-page/index.tsx
@@ -56,7 +56,7 @@ const InformationModelDetailsPage: FC<Props> = ({
     getInformationModelRdfRepresentationsRequested: getInformationModelRdfRepresentations,
     resetInformationModel
   },
-  conceptsActions: { getConceptsRequested: getConcepts },
+  conceptsActions: { getConceptsRequested: getConcepts, resetConcepts },
   match: {
     params: { informationModelId }
   }
@@ -80,6 +80,7 @@ const InformationModelDetailsPage: FC<Props> = ({
 
     return () => {
       resetInformationModel();
+      resetConcepts();
     };
   }, []);
 

--- a/src/components/with-concepts/redux/action-types.ts
+++ b/src/components/with-concepts/redux/action-types.ts
@@ -1,3 +1,5 @@
 export const GET_CONCEPTS_REQUESTED = 'GET_CONCEPTS_REQUESTED' as const;
 export const GET_CONCEPTS_SUCCEEDED = 'GET_CONCEPTS_SUCCEEDED' as const;
 export const GET_CONCEPTS_FAILED = 'GET_CONCEPTS_FAILED' as const;
+
+export const RESET_CONCEPTS = 'RESET_CONCEPTS' as const;

--- a/src/components/with-concepts/redux/actions.ts
+++ b/src/components/with-concepts/redux/actions.ts
@@ -1,7 +1,8 @@
 import {
   GET_CONCEPTS_REQUESTED,
   GET_CONCEPTS_SUCCEEDED,
-  GET_CONCEPTS_FAILED
+  GET_CONCEPTS_FAILED,
+  RESET_CONCEPTS
 } from './action-types';
 
 import { Concept } from '../../../types';
@@ -35,5 +36,11 @@ export function getConceptsFailed(message: string) {
     payload: {
       message
     }
+  };
+}
+
+export function resetConcepts() {
+  return {
+    type: RESET_CONCEPTS
   };
 }

--- a/src/components/with-concepts/redux/reducer.ts
+++ b/src/components/with-concepts/redux/reducer.ts
@@ -1,7 +1,11 @@
 import { fromJS } from 'immutable';
 
 import * as actions from './actions';
-import { GET_CONCEPTS_REQUESTED, GET_CONCEPTS_SUCCEEDED } from './action-types';
+import {
+  GET_CONCEPTS_REQUESTED,
+  GET_CONCEPTS_SUCCEEDED,
+  RESET_CONCEPTS
+} from './action-types';
 
 import { Actions } from '../../../types';
 
@@ -18,6 +22,8 @@ export default function reducer(
       return state.set('concepts', fromJS([]));
     case GET_CONCEPTS_SUCCEEDED:
       return state.set('concepts', fromJS(action.payload.concepts));
+    case RESET_CONCEPTS:
+      return state.set('concepts', fromJS([]));
     default:
       return state;
   }

--- a/src/l10n/en.json
+++ b/src/l10n/en.json
@@ -550,7 +550,8 @@
       "belongsToModule": "Belongs to module",
       "conceptReference": "Concept reference",
       "abstractionOf": "Abstraction of",
-      "realizationOf": "Realization of"
+      "realizationOf": "Realization of",
+      "specializationOf": "Specialization of"
     }
   },
   "sourceRelationship": {

--- a/src/l10n/nb.json
+++ b/src/l10n/nb.json
@@ -550,7 +550,8 @@
       "belongsToModule": "Tilhører modul",
       "conceptReference": "Begrepsreferanse",
       "abstractionOf": "Abstraksjon av",
-      "realizationOf": "Realisering av"
+      "realizationOf": "Realisering av",
+      "specializationOf": "Specialisering av"
     }
   },
   "sourceRelationship": {

--- a/src/l10n/nn.json
+++ b/src/l10n/nn.json
@@ -550,7 +550,8 @@
       "belongsToModule": "Høyrer til modul",
       "conceptReference": "Omgrepsreferanse",
       "abstractionOf": "Abstraksjon av",
-      "realizationOf": "Realisering av"
+      "realizationOf": "Realisering av",
+      "specializationOf": "Spesialisering av"
     }
   },
   "sourceRelationship": {

--- a/src/types/domain.d.ts
+++ b/src/types/domain.d.ts
@@ -93,6 +93,7 @@ export interface InformationModelProperty {
   identifier: string;
   title: Partial<TextLanguage> | null;
   description: Partial<TextLanguage> | null;
+  subject: string | null;
   propertyTypes: string[] | null;
   minOccurs: number | null;
   maxOccurs: number | null;


### PR DESCRIPTION
-fixed keywords links and filter on datasets and inforrmation models
- fixed responsible vs owner on detail page
- fixed specialization references on information models
- fixed concept references on information models structure
- fixed issue on reports page where APIs showing 0
- fixed issue where user was not taken to correct attribute when clicking the attribute on information model structure page