### PR TITLE
fix: set page number like 0 when fetching initial organization assessments

### DIFF
--- a/src/pages/organizations/pages/datasets-page/index.tsx
+++ b/src/pages/organizations/pages/datasets-page/index.tsx
@@ -83,7 +83,7 @@ const DatasetsPage: FC<Props> = ({
         organizationId,
         'dataset',
         isTransportportal ? 'NAP' : 'FDK',
-        assessmentsPage
+        0
       );
 
       getCatalogRating(


### PR DESCRIPTION
Luna fant et problem: `getAssessments` bruker `page` fra forrige gang det ble hentet, så prøver å hente page 1 om du går inn på datasettene til en ny organisasjon etter å ha lastet inn flere datasett for forrige