### PR TITLE
fix(sort-buttons): change responsive styling

### DIFF
--- a/src/pages/search-page/results-all-entities/results-all-entities.component.tsx
+++ b/src/pages/search-page/results-all-entities/results-all-entities.component.tsx
@@ -104,9 +104,7 @@ const ResultsPage: FC<PropsWithChildren<Props>> = ({
     <main id='content'>
       {entities && entities.length > 0 ? (
         <>
-          <div className='row'>
-            <SortButtons />
-          </div>
+          <SortButtons />
           <SC.Content className='row'>
             <SC.Filters className='col-lg-4'>
               <span className='uu-invisible' aria-hidden='false'>

--- a/src/pages/search-page/sort-buttons/index.tsx
+++ b/src/pages/search-page/sort-buttons/index.tsx
@@ -35,7 +35,7 @@ const SortButtons: FC<RouteComponentProps> = ({ history, location }) => {
   };
 
   return (
-    <SC.SortButtons className='col-12'>
+    <SC.SortButtons>
       <ButtonToggleSC.ButtonToggle
         onClick={onSortByScoreClick}
         selected={sortField === undefined}

--- a/src/pages/search-page/sort-buttons/styled.ts
+++ b/src/pages/search-page/sort-buttons/styled.ts
@@ -1,11 +1,18 @@
 import styled from 'styled-components';
 
+import ButtonToggleSC from '../../../components/button-toggle/styled';
+
 const SortButtons = styled.div`
   display: flex;
-  flex-wrap: wrap;
   justify-content: center;
   @media (min-width: 992px) {
     justify-content: flex-end;
+  }
+
+  @media (max-width: 992px) {
+    & > ${ButtonToggleSC.ButtonToggle} {
+      flex-grow: 1;
+    }
   }
 `;
 


### PR DESCRIPTION
I mobilvisning ha sorteringsknappene til å ligge ved siden av og fylle ut hele bredden.