### PR TITLE
chore: add dotenv and prettierrc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+SEARCH_API_HOST=https://www.staging.fellesdatakatalog.digdir.no
+SEARCH_FULLTEXT_HOST=https://search.staging.fellesdatakatalog.digdir.no
+CMS_API_HOST=https://cms-fellesdatakatalog.digdir.no
+ORGANIZATION_HOST=https://organization-bff.staging.fellesdatakatalog.digdir.no
+ORGANIZATION_CATALOGUE_HOST=https://organization-catalogue.staging.fellesdatakatalog.digdir.no
+REPORT_API_HOST=https://reports-bff.staging.fellesdatakatalog.digdir.no
+METADATA_QUALITY_ASSESSMENT_API_HOST=https://metadata-quality.staging.fellesdatakatalog.digdir.no
+FDK_REGISTRATION_BASE_URI=https://registrering.staging.fellesdatakatalog.digdir.no
+ADMIN_GUI_BASE_URI=https://admin.staging.fellesdatakatalog.digdir.no
+INFORMATIONMODEL_HARVESTER_HOST=https://informationmodels.staging.fellesdatakatalog.digdir.no
+FDK_COMMUNITY_BASE_URI=https://community.staging.fellesdatakatalog.digdir.no/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage
 .DS_Store
 .idea
 .project
+
+# Environment files
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
+}

--- a/src/config.js
+++ b/src/config.js
@@ -5,20 +5,6 @@ const env = window.env || {
   USE_DEMO_LOGO: true
 };
 
-// override all env variables to staging (inspired by https://www.staging.fellesdatakatalog.digdir.no/config.js)
-// env.SEARCH_API_HOST = 'https://www.staging.fellesdatakatalog.digdir.no';
-// env.SEARCH_HOST = 'https://www.staging.fellesdatakatalog.digdir.no';
-// env.SEARCH_FULLTEXT_HOST = 'https://search.staging.fellesdatakatalog.digdir.no';
-// env.CMS_API_HOST = 'https://cms-fellesdatakatalog.digdir.no';
-// env.ORGANIZATION_HOST =
-//   'https://organization-bff.staging.fellesdatakatalog.digdir.no';
-// env.ORGANIZATION_CATALOGUE_HOST =
-//   'https://organization-catalogue.staging.fellesdatakatalog.digdir.no';
-// env.REPORT_API_HOST = 'https://reports-bff.staging.fellesdatakatalog.digdir.no';
-// env.METADATA_QUALITY_ASSESSMENT_API_HOST =
-//   'https://metadata-quality.staging.fellesdatakatalog.digdir.no';
-// env.USE_DEMO_LOGO = true;
-
 const searchApi = {
   host: env.SEARCH_API_HOST || '',
   // in ut1 and st1, search api requires basic authentication


### PR DESCRIPTION
Small developer improvement, adds a `.prettierrc` which makes it possible to use in-editor Prettier (like format on save etc).

Adds an example dotenv file, along with an gitignore entry for that file.