### PR TITLE
fix: support empty string as fallback language

### DIFF
--- a/src/lib/translateText.js
+++ b/src/lib/translateText.js
@@ -16,6 +16,7 @@ export function getTranslateText(textObj, language) {
     textObj.no ||
     textObj.nn ||
     textObj.en ||
+    textObj[''] ||
     null
   );
 }


### PR DESCRIPTION
Fixes #969 