### PR TITLE
fix: stop search for data service relations when hasFormat is empty

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -4,6 +4,21 @@
       "decision": "ignore",
       "madeAt": 1628081309814,
       "expiresAt": 1638267933000
+    },
+    "1002531|rdflib>xmldom": {
+      "decision": "ignore",
+      "madeAt": 1633673382488,
+      "expiresAt": 1634278110831
+    },
+    "1002901|@fellesdatakatalog/internal-footer>@fellesdatakatalog/skatteetaten-frontend-components>react-i18next>html-parse-stringify2": {
+      "decision": "ignore",
+      "madeAt": 1633673392906,
+      "expiresAt": 1634278110831
+    },
+    "1002477|@fellesdatakatalog/internal-footer>@fellesdatakatalog/skatteetaten-frontend-components>axios": {
+      "decision": "ignore",
+      "madeAt": 1633673434796,
+      "expiresAt": 1634278210807
     }
   },
   "rules": {},

--- a/src/components/information-model-details-page/index.tsx
+++ b/src/components/information-model-details-page/index.tsx
@@ -216,15 +216,15 @@ const InformationModelDetailsPage: FC<Props> = ({
   }, [informationModelIdentifiers.join()]);
 
   useEffect(() => {
+    const formats =
+      informationModel?.hasFormat?.reduce(
+        (accumulator, { uri }) => (uri ? [...accumulator, uri] : accumulator),
+        [] as string[]
+      ) ?? [];
+    if (formats.length > 0) {
+      getDataServicesRelations({ endpointDescription: formats });
+    }
     if (informationModel?.uri) {
-      getDataServicesRelations({
-        endpointDescription:
-          informationModel?.hasFormat?.reduce(
-            (accumulator, { uri }) =>
-              uri ? [...accumulator, uri] : accumulator,
-            [] as string[]
-          ) ?? []
-      });
       getInformationmodelsRelations({ relations: informationModel.uri });
     }
     return () => {


### PR DESCRIPTION
feks `Felles informasjonsmodell for Adresse` i staging:
![Screenshot from 2021-10-08 08-21-04](https://user-images.githubusercontent.com/50194012/136510922-dcaa4d49-d30c-40ec-9407-42478fd898e0.png)

Etter denne fiksen:
![Screenshot from 2021-10-08 08-20-44](https://user-images.githubusercontent.com/50194012/136511002-ccb77cee-e2ad-45c6-ab84-c6acef0fb159.png)

