### PR TITLE
fix: handle events with missing specialized_type value

### DIFF
--- a/src/components/event-details-page/index.tsx
+++ b/src/components/event-details-page/index.tsx
@@ -147,21 +147,19 @@ const EventDetailsPage: FC<Props> = ({
                       .join(', ')}
                   />
                 )}
-                {specializedType && (
-                  <KeyValueListItem
-                    property={translations.eventType}
-                    value={(() => {
-                      switch (specializedType) {
-                        case SpecializedEventType.LIFEEVENT:
-                          return translations.lifeEvent;
-                        case SpecializedEventType.BUSINESSEVENT:
-                          return translations.businessEvent;
-                        default:
-                          return '';
-                      }
-                    })()}
-                  />
-                )}
+                <KeyValueListItem
+                  property={translations.eventType}
+                  value={(() => {
+                    switch (specializedType) {
+                      case SpecializedEventType.LIFEEVENT:
+                        return translations.lifeEvent;
+                      case SpecializedEventType.BUSINESSEVENT:
+                        return translations.businessEvent;
+                      default:
+                        return '';
+                    }
+                  })()}
+                />
               </KeyValueList>
             </ContentSection>
           )}

--- a/src/components/event-item/index.tsx
+++ b/src/components/event-item/index.tsx
@@ -29,22 +29,20 @@ const EventItem: FC<Props> = ({
     beta
   >
     <SearchHitEvents>
-      {specializedType && (
-        <RoundedTag>
-          <span>
-            {(() => {
-              switch (specializedType) {
-                case SpecializedEventType.LIFEEVENT:
-                  return translations.lifeEvent;
-                case SpecializedEventType.BUSINESSEVENT:
-                  return translations.businessEvent;
-                default:
-                  return '';
-              }
-            })()}
-          </span>
-        </RoundedTag>
-      )}
+      <RoundedTag>
+        <span>
+          {(() => {
+            switch (specializedType) {
+              case SpecializedEventType.LIFEEVENT:
+                return translations.lifeEvent;
+              case SpecializedEventType.BUSINESSEVENT:
+                return translations.businessEvent;
+              default:
+                return '';
+            }
+          })()}
+        </span>
+      </RoundedTag>
     </SearchHitEvents>
   </SearchHit>
 );


### PR DESCRIPTION
fixes #1223 

Klarer nå å vise hendelsen "Vedtak om skjenkebevilling":
![Screenshot from 2022-05-20 13-18-19](https://user-images.githubusercontent.com/50194012/169520134-ae107292-0c12-4985-b0f7-334a1a86c106.png)

