### PR TITLE
fix: show dataset contact details name when url is missing

### DIFF
--- a/src/components/dataset-details-page/index.tsx
+++ b/src/components/dataset-details-page/index.tsx
@@ -866,6 +866,12 @@ const DatasetDetailsPage: FC<Props> = ({
                       }
                     />
                   )}
+                  {!hasURL && organizationUnit && (
+                    <KeyValueListItem
+                      property={translations.contactPoint}
+                      value={translate(organizationUnit)}
+                    />
+                  )}
                   {email && (
                     <KeyValueListItem
                       property={translations.email}


### PR DESCRIPTION
fixes #1347 

Var visst krav om å ha url for at navn skulle vises, la til at kontaktdetaljer vises navn som ikke er link når url ikke er tilgjengelig.

eksempel hvor navn er tilgjengelig, men ikke url:
![Screenshot from 2022-10-28 14-12-21](https://user-images.githubusercontent.com/50194012/198586429-d4c527d1-7514-4d63-84ff-8e47fbf5d4e2.png)

eksempel hvor både navn og url er tilgjengelig:
![Screenshot from 2022-10-28 14-27-56](https://user-images.githubusercontent.com/50194012/198587377-dd2e8bba-8891-4d5e-b27b-2c66194847ee.png)
