### PR TITLE
fix: #1342 - shows "no results found" when loading page

### DIFF
--- a/src/pages/search-page/results-all-entities/results-all-entities.component.tsx
+++ b/src/pages/search-page/results-all-entities/results-all-entities.component.tsx
@@ -102,7 +102,7 @@ const ResultsPage: FC<PropsWithChildren<Props>> = ({
 
   return (
     <main id='content'>
-      {entities && entities.length > 0 ? (
+      {(entities && entities.length > 0) || isLoading ? (
         <>
           <SortButtons />
           <SC.Content className='row'>


### PR DESCRIPTION
Fixes #1342 