### PR TITLE
feat: implement tema and søkeord i tjenestekatalog, closes #1427

### DIFF
--- a/src/components/public-service-details-page/index.tsx
+++ b/src/components/public-service-details-page/index.tsx
@@ -154,6 +154,7 @@ const PublicServiceDetailsPage: FC<Props> = ({
   const hasParticipation = publicService?.hasParticipation ?? [];
   const hasInput = publicService?.hasInput ?? [];
   const hasChannel = publicService?.hasChannel ?? [];
+  const keyword = publicService?.keyword ?? [];
   const hasCost = publicService?.hasCost ?? [];
   const processingTime = publicService?.processingTime;
   const relation = publicService?.relation || [];
@@ -236,6 +237,30 @@ const PublicServiceDetailsPage: FC<Props> = ({
     (previous, current) => ({ ...previous, [current.uri]: current }),
     {} as Record<string, any>
   );
+
+  const losThemes = [
+    {
+      title: {
+        nn: 'Forvaltning og offentleg sektor',
+        no: 'Forvaltning og offentlig sektor',
+        nb: 'Forvaltning og offentlig sektor',
+        en: 'Government and public sector'
+      }
+    },
+    {
+      title: {
+        nn: 'Forvaltning og offentleg sektor',
+        no: 'Forvaltning og offentlig sektor',
+        nb: 'Forvaltning og offentlig sektor',
+        en: 'Government and public sector'
+      }
+    }
+  ];
+
+  const euDataThemes = [
+    { name: { nn: 'Næring', nb: 'Næring', en: 'Business' } },
+    { name: { nn: 'Næring', nb: 'Næring', en: 'Business' } }
+  ];
 
   const eventsRelationsWithRelationType: ItemWithRelationType[] =
     eventsRelations.map(eventRelation => ({
@@ -977,6 +1002,47 @@ const PublicServiceDetailsPage: FC<Props> = ({
               </KeyValueList>
             </ContentSection>
           )}
+          {
+            <ContentSection
+              id='theme-and-searchwords'
+              title={
+                translations.detailsPage.sectionTitles.publicService
+                  .themesAndSearchWords
+              }
+            >
+              <KeyValueList>
+                <KeyValueListItem
+                  key={`losThemes-${1}`}
+                  property={
+                    translations.detailsPage.sectionTitles.publicService.themes
+                  }
+                  value={losThemes
+                    .map(theme => translate(theme.title))
+                    .filter(Boolean)
+                    .join(' • ')}
+                />
+                <KeyValueListItem
+                  key={`euDataThemes-${1}`}
+                  property={
+                    translations.detailsPage.sectionTitles.publicService
+                      .euDataThemes
+                  }
+                  value={euDataThemes
+                    .map(theme => translate(theme.name))
+                    .filter(Boolean)
+                    .join(', ')}
+                />
+                <KeyValueListItem
+                  key={`keywords-${1}`}
+                  property={
+                    translations.detailsPage.sectionTitles.publicService
+                      .keywords
+                  }
+                  value={keyword.map(word => translate(word)).join(' ')}
+                />
+              </KeyValueList>
+            </ContentSection>
+          }
           {serviceHomepages.length > 0 && (
             <ContentSection
               id='serviceHomepages'
@@ -1062,6 +1128,7 @@ const PublicServiceDetailsPage: FC<Props> = ({
               />
             </ContentSection>
           )}
+
           {contactPoints.length > 0 && (
             <ContentSection
               id='hasContactPoint'

--- a/src/l10n/en.json
+++ b/src/l10n/en.json
@@ -746,7 +746,10 @@
         "requirement": "Requirement",
         "satisfiesRule": "Satisfies rule",
         "openingHours": "Opening hours",
-        "contactPage": "Contact page"
+        "contactPage": "Contact page",
+        "themesAndSearchWords": "Themes and search words",
+        "themes": "Themes",
+        "euDataThemes": "Eu themes"
       },
       "event": {
         "description": "Description",

--- a/src/l10n/nb.json
+++ b/src/l10n/nb.json
@@ -746,7 +746,10 @@
         "requirement": "Krav",
         "satisfiesRule": "Tilfredsstiller regel",
         "openingHours": "Åpningstider",
-        "contactPage": "Kontaktside"
+        "contactPage": "Kontaktside",
+        "themesAndSearchWords": "Tema og søkeord",
+        "themes": "Tema",
+        "euDataThemes": "Eu-tema"
       },
       "event": {
         "description": "Beskrivelse",

--- a/src/l10n/nn.json
+++ b/src/l10n/nn.json
@@ -746,7 +746,10 @@
         "openingHours": "Opningstider",
         "contactPage": "Kontaktsie",
         "requirement": "Krav",
-        "satisfiesRule": "Tilfredsstiller regel"
+        "satisfiesRule": "Tilfredsstiller regel",
+        "themesAndSearchWords": "Tema og søkeord",
+        "themes": "Tema",
+        "euDataThemes": "Eu-tema"
       },
       "event": {
         "description": "Beskriving",


### PR DESCRIPTION
- [ ] Oppdatert til å bruke data fra parseren
- [ ] Flytt tema og søkeord komponenten til riktig plassering i forhold til de andre komponentene

#1427 