### PR TITLE
fix: changed eslinter to ignore importing rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,6 +87,13 @@
         "ignoreRestSiblings": true
       }
     ],
+    "react/function-component-definition": [
+      2,
+      {
+        "namedComponents": "arrow-function",
+        "unnamedComponents": "arrow-function"
+      }
+    ],
     "@typescript-eslint/no-use-before-define": ["error"],
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-shadow": ["error"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,13 +82,6 @@
         "varsIgnorePattern": "^_|^import"
       }
     ],
-    "react/function-component-definition": [
-      2,
-      {
-        "namedComponents": "arrow-function",
-        "unnamedComponents": "arrow-function"
-      }
-    ],
     "@typescript-eslint/no-use-before-define": ["error"],
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-shadow": ["error"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,13 +67,7 @@
         "allow": ["arrowFunctions"]
       }
     ],
-    "@typescript-eslint/consistent-type-imports": [
-      "error",
-      {
-        "prefer": "type-imports",
-        "disallowTypeAnnotations": false
-      }
-    ],
+    "@typescript-eslint/consistent-type-imports": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
@@ -84,7 +78,8 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
-        "ignoreRestSiblings": true
+        "ignoreRestSiblings": true,
+        "varsIgnorePattern": "^_|^import"
       }
     ],
     "react/function-component-definition": [


### PR DESCRIPTION
Er en regel eslinter har for imports i typescript som trigger når man gjør endringer, det er bare en regel som skal gjøre importer mer generiske og ikke kombinere declerations og expressions (sånn jeg forsto den). Lagt inn en ignore for denne regelen i eslinter som gjør at man får commited kode til branch uten å få feil i importer som man ellers ikke hadde rørt i kodeendringen sin uansett.

Alternativer er at ved hver gang man gjør en kodeendring i en fil så må man fixe importen slik at eslinter regelen blir fornøyd, uten at det egentlig skal ha noe påvirkning på noe annet enn blidgjøre regelen å gjøre disse import endringene ser jeg ikke behovet for å faktisk ta den jobben, og heller da har ignore slik at man faktisk får pushet kode til repo. 

Men kjører gjerne en debatt om noen har andre meninger eller innsyn på hva regelen sier og ønsker forbedre ved koden.

[ESlint regel](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md)