### PR TITLE
fix: closes #1484 bug - "description" shows when no description

### DIFF
--- a/src/components/public-service-details-page/index.tsx
+++ b/src/components/public-service-details-page/index.tsx
@@ -597,13 +597,17 @@ const PublicServiceDetailsPage: FC<Props> = ({
                   index
                 ) => (
                   <div id={`${followsUri}-${index}`}>
-                    {title && (
+                    {name ? (
                       <SC.KeyValueListHeader>
                         {translate(name)}
                       </SC.KeyValueListHeader>
+                    ) : (
+                      <Link href={followsUri} external>
+                        {followsUri}
+                      </Link>
                     )}
                     <KeyValueList>
-                      {description && (
+                      {followsDescription && (
                         <KeyValueListItem
                           key={`followsDescription-${index}`}
                           property={


### PR DESCRIPTION
 beskrivelse shows even though object does not have beskrivelse #1484 