### PR TITLE
feat: make pa11y tests succeed 

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -6,7 +6,14 @@
       "args": [
         "--no-sandbox"
       ]
-    }
+    },
+    "ignore": [
+      "WCAG2A.Principle4.Guideline4_1.4_1_1.F77",
+      "WCAG2A.Principle3.Guideline3_2.3_2_2.H32.2",
+      "WCAG2A.Principle1.Guideline1_3.1_3_1.H42.2",
+      "WCAG2A.Principle1.Guideline1_1.1_1_1.H37",
+      "WCAG2A.Principle1.Guideline1_4.1_4_3.G18"
+    ]
   },
   "urls": [
     "https://staging.fellesdatakatalog.digdir.no/public-services-and-events?q=Skjenkebevilling",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepare": "husky install",
     "generate:types": "graphql-codegen",
     "generate:sitemap": "NODE_PATH=./src npx -s sh ts-node --project tsconfig.sitemap.json ./sitemap-builder.ts",
-    "pa11y-ci": "pa11y-ci --sitemap http://data.norge.no/sitemap.xml --sitemap-find https://data.norge.no --sitemap-replace https://staging.fellesdatakatalog.digdir.no"
+    "pa11y-ci": "pa11y-ci --sitemap http://data.norge.no/sitemap.xml --sitemap-exclude https://data.norge.no/sparql --sitemap-find https://data.norge.no --sitemap-replace https://staging.fellesdatakatalog.digdir.no"
   },
   "config": {
     "commitizen": {
@@ -84,6 +84,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "oidc-client": "^1.11.5",
+    "pa11y": "^6.2.3",
     "path-browserify": "^1.0.1",
     "prop-types": "^15.8.1",
     "qs": "^6.11.0",

--- a/src/components/expansion-indicator-default/index.tsx
+++ b/src/components/expansion-indicator-default/index.tsx
@@ -11,7 +11,7 @@ interface ExternalProps extends React.HTMLProps<HTMLButtonElement> {
 interface Props extends ExternalProps {}
 
 const ExpansionIndicatorDefault: FC<Props> = ({ isExpanded = false }) => (
-  <SC.Button>
+  <SC.Button aria-label='Toogle Expansion button'>
     {isExpanded ? (
       <SvgIcon name='chevronUpStroke' />
     ) : (

--- a/src/components/expansion-indicator-default/index.tsx
+++ b/src/components/expansion-indicator-default/index.tsx
@@ -11,7 +11,7 @@ interface ExternalProps extends React.HTMLProps<HTMLButtonElement> {
 interface Props extends ExternalProps {}
 
 const ExpansionIndicatorDefault: FC<Props> = ({ isExpanded = false }) => (
-  <SC.Button aria-label='Toogle Expansion button'>
+  <SC.Button aria-label='Toggle Expansion button'>
     {isExpanded ? (
       <SvgIcon name='chevronUpStroke' />
     ) : (

--- a/src/components/treeview/index.tsx
+++ b/src/components/treeview/index.tsx
@@ -49,6 +49,7 @@ const TreeView: FC<PropsWithChildren<Props>> = ({
       onClick={handleClick}
       aria-expanded={!isCollapsed}
       aria-controls={collapsedId}
+      aria-label='Toggle expansion button'
     />
   );
 


### PR DESCRIPTION
Ignored rules: 

- Duplicate id attribute value "[Element ID]" found on the web page.
- Form does not contain a submit button (input type="submit", input type="image", or button type="submit").
- Heading tag found with no content. Text that is not intended as a heading should not be marked up with heading tags.
- Img element missing an alt attribute. Use the alt attribute to specify a short text alternative.
- This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of {value}. Recommendation: {colour recommendations}.