### PR TITLE
chore: handle concept subjects as list of objects

### DIFF
--- a/src/components/concept-details-page/index.tsx
+++ b/src/components/concept-details-page/index.tsx
@@ -1,6 +1,8 @@
-import React, { memo, FC, useState, useEffect } from 'react';
+import type { FC } from 'react';
+import React, { memo, useState, useEffect } from 'react';
 import { compose } from 'redux';
-import { RouteComponentProps, Link as RouteLink } from 'react-router-dom';
+import type { RouteComponentProps } from 'react-router-dom';
+import { Link as RouteLink } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import Link from '@fellesdatakatalog/link';
 
@@ -18,15 +20,16 @@ import { themeFDK } from '../../app/theme';
 
 import { PATHNAME_CONCEPTS } from '../../constants/constants';
 
-import withConcept, { Props as ConceptProps } from '../with-concept';
-import withDatasets, { Props as DatasetsProps } from '../with-datasets';
-import withInformationModels, {
-  Props as InformationModelsProps
-} from '../with-information-models';
-import withConcepts, { Props as ConceptsProps } from '../with-concepts';
-import withPublicServices, {
-  Props as PublicServicesProps
-} from '../with-public-services';
+import type { Props as ConceptProps } from '../with-concept';
+import withConcept from '../with-concept';
+import type { Props as DatasetsProps } from '../with-datasets';
+import withDatasets from '../with-datasets';
+import type { Props as InformationModelsProps } from '../with-information-models';
+import withInformationModels from '../with-information-models';
+import type { Props as ConceptsProps } from '../with-concepts';
+import withConcepts from '../with-concepts';
+import type { Props as PublicServicesProps } from '../with-public-services';
+import withPublicServices from '../with-public-services';
 import withErrorBoundary from '../with-error-boundary';
 
 import DetailsPage, {
@@ -36,7 +39,8 @@ import DetailsPage, {
 } from '../details-page';
 import ErrorPage from '../error-page';
 import MultiLingualField from '../multilingual-field';
-import RelationList, { ItemWithRelationType } from '../relation-list';
+import type { ItemWithRelationType } from '../relation-list';
+import RelationList from '../relation-list';
 
 import SC from './styled';
 
@@ -243,7 +247,10 @@ const ConceptDetailsPage: FC<Props> = ({
   const altLabels = concept?.altLabel ?? [];
   const hiddenLabels = concept?.hiddenLabel ?? [];
   const example = concept?.example;
-  const subject = concept?.subject;
+  const subjectLabels =
+    concept?.subject
+      ?.map(s => s.label)
+      ?.filter((element): element is Partial<TextLanguage> => !!element) ?? [];
   const applications = concept?.application ?? [];
   const range = translate(concept?.definition?.range?.text);
   const rangeUri = concept?.definition?.range?.uri;
@@ -404,7 +411,8 @@ const ConceptDetailsPage: FC<Props> = ({
             <MultiLingualField languages={selectedLanguages} text={example} />
           </ContentSection>
         )}
-        {((subject && hasFieldSelectedLanguage([subject])) ||
+        {((subjectLabels.length > 0 &&
+          hasFieldSelectedLanguage(subjectLabels)) ||
           hasFieldSelectedLanguage(applications)) && (
           <ContentSection
             id='domain'
@@ -414,16 +422,19 @@ const ConceptDetailsPage: FC<Props> = ({
             }
           >
             <KeyValueList>
-              {subject && hasFieldSelectedLanguage([subject]) && (
+              {subjectLabels && hasFieldSelectedLanguage(subjectLabels) && (
                 <KeyValueListItem
                   property={translations.concept.subject}
-                  value={
-                    <MultiLingualField
-                      languages={selectedLanguages}
-                      text={subject}
-                      useFallback={false}
-                    />
-                  }
+                  value={languageSorter(subjectLabels).map(
+                    (subjectLabel, index) => (
+                      <MultiLingualField
+                        key={index}
+                        languages={selectedLanguages}
+                        text={subjectLabel}
+                        useFallback={false}
+                      />
+                    )
+                  )}
                 />
               )}
               {applications.length > 0 &&

--- a/src/types/domain.d.ts
+++ b/src/types/domain.d.ts
@@ -263,7 +263,7 @@ export interface Concept {
   definition?: ConceptDefinition;
   publisher: Partial<Organization>;
   example: Partial<TextLanguage>;
-  subject?: Partial<TextLanguage>;
+  subject?: Partial<ConceptSubject>[];
   application?: Partial<TextLanguage>[];
   harvest?: Partial<Harvest>;
   contactPoint?: Partial<ConceptContactPoint>;
@@ -283,6 +283,10 @@ export interface ConceptDefinition {
   sources?: Array<{ text?: string; uri?: stirng }>;
   range?: { text?: Partial<TextLanguage>; uri?: stirng };
   sourceRelationship?: string;
+}
+
+export interface ConceptSubject {
+  label?: Partial<TextLanguage>;
 }
 
 export interface PublicServiceType {


### PR DESCRIPTION
Regner med at det kommer nytt design på dette senere, nå i første omgang legger jeg bare opp til at den klarer å vise alt i gammelt design.

Eksempel på begrep med lang liste literals i fagområde-feltet:
![Screenshot from 2023-08-25 12-13-24](https://github.com/Informasjonsforvaltning/fdk-portal/assets/50194012/2949be29-709f-4cef-b294-c6f297a86779)


Eksempel på hvordan det ser ut for noen som har valgt fagområde fra kodeliste i registrering:
![Screenshot from 2023-08-25 13-35-46](https://github.com/Informasjonsforvaltning/fdk-portal/assets/50194012/0ccc2926-4eef-4052-a133-89056463e4d0)
