### PR TITLE
fix(concept): hide empty fields

### DIFF
--- a/src/components/concept-details-page/index.tsx
+++ b/src/components/concept-details-page/index.tsx
@@ -316,22 +316,23 @@ const ConceptDetailsPage: FC<Props> = ({
         themes={themes}
         languages={selectedLanguages}
       >
-        <ContentSection
-          id='concept-info'
-          title={translations.detailsPage.sectionTitles.concept.conceptInfo}
-          truncate
-        >
-          <KeyValueList>
-            <KeyValueListItem
-              property={`${translations.dateCreated}:`}
-              value={formatISO(created, {
-                year: 'numeric',
-                month: 'numeric',
-                day: 'numeric'
-              })}
-            />
-          </KeyValueList>
-        </ContentSection>
+        {created && (
+          <ContentSection
+            id='concept-info'
+            title={translations.detailsPage.sectionTitles.concept.conceptInfo}
+            truncate
+          >
+            {created && (
+              <KeyValueList>
+                <KeyValueListItem
+                  property={`${translations.dateCreated}:`}
+                  value={formatISO(created)}
+                />
+              </KeyValueList>
+            )}
+          </ContentSection>
+        )}
+
         {description && (
           <ContentSection
             id='description'

--- a/src/utils/date/index.ts
+++ b/src/utils/date/index.ts
@@ -1,12 +1,21 @@
+/**
+ * Format ISO date string to locale string
+ * @param isoDate ISO date string
+ * @param options available format options
+ *     weekday: 'long',
+ *     year: 'numeric',
+ *     month: 'long',
+ *     day: 'numeric',
+ *     hour: '2-digit',
+ *     minute: '2-digit'
+ * @returns formatted date string
+ */
 export const formatISO = (
   isoDate: string,
   options: Intl.DateTimeFormatOptions = {
-    weekday: 'long',
     year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
+    month: 'numeric',
+    day: 'numeric'
   }
 ) => {
   if (!isoDate) {


### PR DESCRIPTION
- skjuler "Begrepsinformasjon"-boksen når det er ingen info å vise.
- defaulter outputen av isoFormat til å være det formatet som er mest spredt i våre kodebaser.