### PR TITLE
Fix: remove image from search-button

### DIFF
--- a/src/components/search-box/components/search-form/styled.ts
+++ b/src/components/search-box/components/search-form/styled.ts
@@ -64,11 +64,6 @@ const SearchForm = styled.form`
       outline-offset: 3px;
       outline: 2px solid orange;
     }
-
-    & > img {
-      margin-right: 0.2em;
-      width: 1em;
-    }
   }
 `;
 


### PR DESCRIPTION
The fix removes the image field from the search button, as it was no longer in use. We have removed the image from the search button earlier. The image was described as <image alt> in the source code, and could lead to confusion for vision impaired users.