### PR TITLE
fix: open access request link in new a tab

### DIFF
--- a/src/components/details-page/components/details-page/index.tsx
+++ b/src/components/details-page/components/details-page/index.tsx
@@ -343,7 +343,11 @@ const DetailsPage: FC<PropsWithChildren<Props>> = ({
       </SC.Themes>
       {accessRequest && (
         <SC.AccessRequest>
-          <a href={accessRequest.requestAddress}>
+          <a
+            href={accessRequest.requestAddress}
+            target='_blank'
+            rel='noreferrer'
+          >
             <Button>{translations.detailsPage.requestDataButton}</Button>
           </a>
         </SC.AccessRequest>


### PR DESCRIPTION
A fix to open the link in a new tab after clicking on the access request button.