### PR TITLE
fix: empty container elements (invalid html siteimprove error)

### DIFF
--- a/src/components/details-page/components/details-page/index.tsx
+++ b/src/components/details-page/components/details-page/index.tsx
@@ -250,6 +250,91 @@ const DetailsPage: FC<PropsWithChildren<Props>> = ({
     ? Object.values(datasetScores.scores)[0]
     : null;
 
+  const renderThemeItems = () => {
+    let items = [];
+    if (isOpenData) {
+      items.push(
+        <SC.ThemeItem>
+          <Link
+            to={`${rootPaths[entity]}?opendata=true`}
+            className='open-data'
+          >
+            <OpenAccessIcon />
+            {translations.detailsPage.openData}
+          </Link>
+        </SC.ThemeItem>
+      );
+    }
+
+    if (isPublicData) {
+      items.push(
+        <SC.ThemeItem>
+          <Link
+            to={`${rootPaths[entity]}?accessrights=PUBLIC`}
+            className='public-data'
+          >
+            <OpenAccessIcon />
+            {translations.detailsPage.publicData}
+          </Link>
+        </SC.ThemeItem>
+      );
+    }
+
+    if (isRestrictedData) {
+      items.push(
+        <SC.ThemeItem>
+          <Link
+            to={`${rootPaths[entity]}?accessrights=RESTRICTED`}
+            className='restricted-data'
+          >
+            <RestrictedAccessIcon />
+            {translations.detailsPage.restrictedData}
+          </Link>
+        </SC.ThemeItem>
+      );
+    }
+
+    if (isNonPublicData) {
+      items.push(
+        <SC.ThemeItem>
+          <Link
+            to={`${rootPaths[entity]}?accessrights=NON_PUBLIC`}
+            className='non-public-data'
+          >
+            <NotOpenAccessIcon />
+            {translations.detailsPage.nonPublicData}
+          </Link>
+        </SC.ThemeItem>
+      );
+    }
+
+    items = [
+      ...items,
+      ...themes.map(theme => {
+        if (isLosTheme(theme)) {
+          const { uri, name, losPaths: [losPath] = [] } = theme;
+          return (
+            <SC.ThemeItem key={uri}>
+              <Link key={uri} to={`${rootPaths[entity]}?losTheme=${losPath}`}>
+                {translate(name)}
+              </Link>
+            </SC.ThemeItem>
+          );
+        }
+        if (isEuTheme(theme)) {
+          const { id, title: themeTitle, label: themeLabel, code } = theme;
+          return (
+            <Link key={id} to={`${rootPaths[entity]}?theme=${code}`}>
+              {themeTitle ? translate(themeTitle) : translate(themeLabel)}
+            </Link>
+          );
+        }
+        return null;
+      })
+    ];
+    return items.filter(Boolean);
+  };
+
   return (
     <SC.DetailsPage className='container' id='content'>
       <Banner
@@ -274,73 +359,12 @@ const DetailsPage: FC<PropsWithChildren<Props>> = ({
           </FdkLink>
         </SC.SubBanner>
       )}
-      <SC.Themes>
-        {isOpenData && (
-          <SC.ThemeItem>
-            <Link
-              to={`${rootPaths[entity]}?opendata=true`}
-              className='open-data'
-            >
-              <OpenAccessIcon />
-              {translations.detailsPage.openData}
-            </Link>
-          </SC.ThemeItem>
-        )}
-        {isPublicData && (
-          <SC.ThemeItem>
-            <Link
-              to={`${rootPaths[entity]}?accessrights=PUBLIC`}
-              className='public-data'
-            >
-              <OpenAccessIcon />
-              {translations.detailsPage.publicData}
-            </Link>
-          </SC.ThemeItem>
-        )}
-        {isRestrictedData && (
-          <SC.ThemeItem>
-            <Link
-              to={`${rootPaths[entity]}?accessrights=RESTRICTED`}
-              className='restricted-data'
-            >
-              <RestrictedAccessIcon />
-              {translations.detailsPage.restrictedData}
-            </Link>
-          </SC.ThemeItem>
-        )}
-        {isNonPublicData && (
-          <SC.ThemeItem>
-            <Link
-              to={`${rootPaths[entity]}?accessrights=NON_PUBLIC`}
-              className='non-public-data'
-            >
-              <NotOpenAccessIcon />
-              {translations.detailsPage.nonPublicData}
-            </Link>
-          </SC.ThemeItem>
-        )}
-        {themes.map(theme => {
-          if (isLosTheme(theme)) {
-            const { uri, name, losPaths: [losPath] = [] } = theme;
-            return (
-              <SC.ThemeItem key={uri}>
-                <Link key={uri} to={`${rootPaths[entity]}?losTheme=${losPath}`}>
-                  {translate(name)}
-                </Link>
-              </SC.ThemeItem>
-            );
-          }
-          if (isEuTheme(theme)) {
-            const { id, title: themeTitle, label: themeLabel, code } = theme;
-            return (
-              <Link key={id} to={`${rootPaths[entity]}?theme=${code}`}>
-                {themeTitle ? translate(themeTitle) : translate(themeLabel)}
-              </Link>
-            );
-          }
-          return null;
-        })}
-      </SC.Themes>
+      {
+        renderThemeItems().length > 0 &&
+        <SC.Themes>
+          {renderThemeItems()}
+        </SC.Themes>
+      }
       {accessRequest && (
         <SC.AccessRequest>
           <a

--- a/src/components/details-page/components/key-value-list/index.tsx
+++ b/src/components/details-page/components/key-value-list/index.tsx
@@ -15,21 +15,25 @@ import MemberOf from '../RelatedConcepts/MemberOf';
 import PartitiveRelations from '../RelatedConcepts/PartitiveRelations';
 import SeeAlso from '../RelatedConcepts/SeeAlso';
 
-const KeyValueList: FC<PropsWithChildren<any>> = ({ children, ...props }) => (
-  <SC.List {...props}>
-    {Children.map(children, child =>
-      isValidElement(child) &&
-      (child.type === KeyValueListItem ||
-        child.type === AssociativeRelations ||
-        child.type === GenericRelations ||
-        child.type === IsReplacedBy ||
-        child.type === MemberOf ||
-        child.type === PartitiveRelations ||
-        child.type === SeeAlso)
-        ? child
-        : null
-    )}
-  </SC.List>
-);
+const KeyValueList: FC<PropsWithChildren<any>> = ({ children, ...props }) => {
+  const hasChildren = React.Children.count(children) > 0;
+  if (!hasChildren) return (<></>);
+  return (
+    <SC.List {...props}>
+      {Children.map(children, child =>
+        isValidElement(child) &&
+        (child.type === KeyValueListItem ||
+          child.type === AssociativeRelations ||
+          child.type === GenericRelations ||
+          child.type === IsReplacedBy ||
+          child.type === MemberOf ||
+          child.type === PartitiveRelations ||
+          child.type === SeeAlso)
+          ? child
+          : null
+      )}
+    </SC.List>
+  );
+}
 
 export default memo(KeyValueList);

--- a/src/components/details-page/components/list/index.tsx
+++ b/src/components/details-page/components/list/index.tsx
@@ -10,10 +10,14 @@ import SC from './styled';
 
 interface Props {}
 
-const List: FC<PropsWithChildren<Props>> = ({ children, ...props }) => (
-  <SC.List {...props}>
-    {Children.map(children, child => (isValidElement(child) ? child : null))}
-  </SC.List>
-);
+const List: FC<PropsWithChildren<Props>> = ({ children, ...props }) => {
+  const hasChildren = React.Children.count(children) > 0;
+  if (!hasChildren) return (<></>);
+  return (
+    <SC.List {...props}>
+      {Children.map(children, child => (isValidElement(child) ? child : null))}
+    </SC.List>
+  );
+}
 
 export default memo(List);

--- a/src/pages/public-service-details-page/index.tsx
+++ b/src/pages/public-service-details-page/index.tsx
@@ -384,40 +384,44 @@ const PublicServiceDetailsPage: FC<Props> = ({
             >
               <List>
                 {requiredServices?.map(({ uri }, index) => (
-                  <CatalogTypeBox entity={Entity.PUBLIC_SERVICE}>
-                    <span>
-                      {translations.requires}&nbsp;
-                      {publicServicesMap?.[uri] ? (
-                        <Link
-                          as={RouterLink}
-                          to={`${PATHNAME_PUBLIC_SERVICES}/${publicServicesMap[uri].id}`}
-                          key={`${uri}-${index}`}
-                        >
-                          {translate(publicServicesMap[uri].title) ?? uri}
-                        </Link>
-                      ) : (
-                        uri
-                      )}
-                    </span>
-                  </CatalogTypeBox>
+                  <li key={`${uri}-${index}`}>
+                    <CatalogTypeBox entity={Entity.PUBLIC_SERVICE}>
+                      <span>
+                        {translations.requires}&nbsp;
+                        {publicServicesMap?.[uri] ? (
+                          <Link
+                            as={RouterLink}
+                            to={`${PATHNAME_PUBLIC_SERVICES}/${publicServicesMap[uri].id}`}
+                            key={`${uri}-${index}`}
+                          >
+                            {translate(publicServicesMap[uri].title) ?? uri}
+                          </Link>
+                        ) : (
+                          uri
+                        )}
+                      </span>
+                    </CatalogTypeBox>
+                  </li>
                 ))}
                 {relation?.map(({ uri }, index) => (
-                  <CatalogTypeBox entity={Entity.PUBLIC_SERVICE}>
-                    <span>
-                      {translations.isRelatedTo}&nbsp;
-                      {publicServicesMap?.[uri] ? (
-                        <Link
-                          as={RouterLink}
-                          to={`${PATHNAME_PUBLIC_SERVICES}/${publicServicesMap[uri].id}`}
-                          key={`${uri}-${index}`}
-                        >
-                          {translate(publicServicesMap[uri].title) ?? uri}
-                        </Link>
-                      ) : (
-                        uri
-                      )}
-                    </span>
-                  </CatalogTypeBox>
+                  <li key={`${uri}-${index}`}>
+                    <CatalogTypeBox entity={Entity.PUBLIC_SERVICE}>
+                      <span>
+                        {translations.isRelatedTo}&nbsp;
+                        {publicServicesMap?.[uri] ? (
+                          <Link
+                            as={RouterLink}
+                            to={`${PATHNAME_PUBLIC_SERVICES}/${publicServicesMap[uri].id}`}
+                            key={`${uri}-${index}`}
+                          >
+                            {translate(publicServicesMap[uri].title) ?? uri}
+                          </Link>
+                        ) : (
+                          uri
+                        )}
+                      </span>
+                    </CatalogTypeBox>
+                  </li>
                 ))}
               </List>
             </ContentSection>
@@ -431,23 +435,25 @@ const PublicServiceDetailsPage: FC<Props> = ({
               }
             >
               <List>
-                {isGroupedBy?.map(uri =>
+                {isGroupedBy?.map((uri, index) =>
                   eventsMap[uri] ? (
-                    <CatalogTypeBox key={uri} entity={Entity.EVENT}>
-                      <span>
-                        {translations.isGroupedBy}&nbsp;
-                        {eventsMap[uri].id ? (
-                          <Link
-                            as={RouterLink}
-                            to={`${PATHNAME_EVENTS}/${eventsMap[uri].id}`}
-                          >
-                            {translate(eventsMap[uri].title ?? uri)}
-                          </Link>
-                        ) : (
-                          uri
-                        )}
-                      </span>
-                    </CatalogTypeBox>
+                    <li key={`${uri}-${index}`}>
+                      <CatalogTypeBox key={uri} entity={Entity.EVENT}>
+                        <span>
+                          {translations.isGroupedBy}&nbsp;
+                          {eventsMap[uri].id ? (
+                            <Link
+                              as={RouterLink}
+                              to={`${PATHNAME_EVENTS}/${eventsMap[uri].id}`}
+                            >
+                              {translate(eventsMap[uri].title ?? uri)}
+                            </Link>
+                          ) : (
+                            uri
+                          )}
+                        </span>
+                      </CatalogTypeBox>
+                    </li>
                   ) : null
                 )}
               </List>
@@ -463,25 +469,27 @@ const PublicServiceDetailsPage: FC<Props> = ({
             >
               <List>
                 {subject?.map(
-                  ({ uri, prefLabel }) =>
+                  ({ uri, prefLabel }, index) =>
                     uri && (
-                      <CatalogTypeBox entity={Entity.CONCEPT}>
-                        {conceptsMap[uri] ? (
-                          <Link
-                            as={RouterLink}
-                            to={`${PATHNAME_CONCEPTS}/${conceptsMap[uri].id}`}
-                          >
-                            {translate(conceptsMap[uri].prefLabel)}
-                          </Link>
-                        ) : (
-                          translate(prefLabel)
-                        )}
-                        <div>
-                          {conceptsMap[uri]
-                            ? translate(conceptsMap[uri].definition?.text)
-                            : uri}
-                        </div>
-                      </CatalogTypeBox>
+                      <li key={`${uri}-${index}`}>
+                        <CatalogTypeBox entity={Entity.CONCEPT}>
+                          {conceptsMap[uri] ? (
+                            <Link
+                              as={RouterLink}
+                              to={`${PATHNAME_CONCEPTS}/${conceptsMap[uri].id}`}
+                            >
+                              {translate(conceptsMap[uri].prefLabel)}
+                            </Link>
+                          ) : (
+                            translate(prefLabel)
+                          )}
+                          <div>
+                            {conceptsMap[uri]
+                              ? translate(conceptsMap[uri].definition?.text)
+                              : uri}
+                          </div>
+                        </CatalogTypeBox>
+                      </li>
                     )
                 )}
               </List>
@@ -1239,21 +1247,22 @@ const PublicServiceDetailsPage: FC<Props> = ({
               }
             >
               <List>
-                {datasetsUris?.map(
-                  uri =>
+                {datasetsUris?.map((uri, index) =>
                     uri && (
-                      <CatalogTypeBox entity={Entity.DATASET}>
-                        {datasetsMap[uri] ? (
-                          <Link
-                            as={RouterLink}
-                            to={`${PATHNAME_DATASETS}/${datasetsMap[uri].id}`}
-                          >
-                            {translate(datasetsMap[uri].title)}
-                          </Link>
-                        ) : (
-                          translate(uri)
-                        )}
-                      </CatalogTypeBox>
+                      <li key={`${uri}-${index}`}>
+                        <CatalogTypeBox entity={Entity.DATASET}>
+                          {datasetsMap[uri] ? (
+                            <Link
+                              as={RouterLink}
+                              to={`${PATHNAME_DATASETS}/${datasetsMap[uri].id}`}
+                            >
+                              {translate(datasetsMap[uri].title)}
+                            </Link>
+                          ) : (
+                            translate(uri)
+                          )}
+                        </CatalogTypeBox>
+                      </li>
                     )
                 )}
               </List>

--- a/src/pages/requests/index.tsx
+++ b/src/pages/requests/index.tsx
@@ -3,7 +3,6 @@ import { compose } from 'redux';
 import Link from '@fellesdatakatalog/link';
 import Button from '@fellesdatakatalog/button';
 import Select from 'react-select';
-import { Breadcrumb } from 'reactstrap';
 import withCommunity, {
   Props as CommunityProps
 } from '../../components/with-community';
@@ -61,7 +60,6 @@ const RequestsPage: FC<Props> = ({
 
   return (
     <>
-      <Breadcrumb />
       <Banner title={localization.requestsPage.title} />
       <main id='content' className='container'>
         <SC.FirstRow>


### PR DESCRIPTION
- Fjerner tom/ubrukt `<Breadcrumbs />`-komponent på Requests page
- Betinget rendring av Theme kontainer på DetailsPage kun hvis den har barn
- Betinget rendring av `<ul></ul>` kontainer i KeyValueList kun hvis den har barn
- Oppdatert hver instans hvor DetailsPage/List-komponenten blir brukt til å wrappe barna i `<li>`-elementer, la også til betinget rendring av `<ul></ul>` kun hvis den har barn

Resolves #1843 