### PR TITLE
fix: remove sticky menu from concept details page

### DIFF
--- a/src/components/details-page/components/details-page/index.tsx
+++ b/src/components/details-page/components/details-page/index.tsx
@@ -345,8 +345,12 @@ const DetailsPage: FC<PropsWithChildren<Props>> = ({
           <SC.HamburgerIcon />
           {translations.detailsPage.navMenuButton[navOpen ? 'open' : 'closed']}
         </SC.MenuToggle>
-        <SC.SideMenu isSticky={isSticky} menuItems={menuItems} />
-        {navOpen && <SC.SideMenuSmall menuItems={menuItems} />}
+        {entity !== Entity.CONCEPT && (
+          <>
+            <SC.SideMenu isSticky={isSticky} menuItems={menuItems} />
+            {navOpen && <SC.SideMenuSmall menuItems={menuItems} />}
+          </>
+        )}
         <SC.Content>{renderContentSections()}</SC.Content>
         {renderAside()}
       </SC.Page>


### PR DESCRIPTION
closes https://github.com/Informasjonsforvaltning/fdk-frontend/issues/105
closes https://github.com/Informasjonsforvaltning/fdk-portal/issues/2019

Problem: Lenkene i sticky menyen blir laget ved å se på barna til en detaljside og sjekke om det er av type ConcentSection og om de har tittel og id. På detaljsiden til begrep er det blitt gjort en refakturering slik at alle contentSections er wrappet i en annen komponent, som gjør at funksjonen ikke finner noen barn av type contentSection. 

Kan løses vist man vil, men da må man enten 1) refakturere sticky meny komponenten (best men mye jobb), 2) hacky løsning 3) "tilbakestille" refaktureringen. 

Da ingen av disse løsningene er spesielt gunstige konkluderte vi med at det beste er å fjerne menyen helt KUN på begrep sin detaljside, da menyen uansett ikke gir så mye verdi slik den er i dag. 