### PR TITLE
Add tenor to white list in prod

### DIFF
--- a/src/white-list.ts
+++ b/src/white-list.ts
@@ -24,5 +24,9 @@ export const accessRequestWhiteList: AccessRequest[] = [
   {
     id: 'e281c8c6-b944-4662-861d-a475e973e393',
     requestAddress: 'https://www.skatteetaten.no/deling/folkeregisteret/intro/'
+  },
+  {
+    id: '95b9c74d-1dd4-3f92-aef2-a6a587b03fb3',
+    requestAddress: 'https://digdir.apps.altinn.no/digdir/tilgangssoknad-tenor/'
   }
 ];


### PR DESCRIPTION
[Tenor](https://skatteetaten.github.io/testnorge-tenor-dokumentasjon/#:~:text=Hvordan%20f%C3%A5%20tilgang%20til%20API%2Det%20for%20s%C3%B8k&text=For%20%C3%A5%20f%C3%A5%20tilgang%20m%C3%A5,til%20s%C3%B8ke%2DAPI'et.) ha nå gitt tommel opp for å ha [dette APIet](https://data.norge.no/data-services/95b9c74d-1dd4-3f92-aef2-a6a587b03fb3) som en del av søknadsløsningen i prod 🚀 
Legger det til med link til [søknaden i Altinn](https://digdir.apps.altinn.no/digdir/tilgangssoknad-tenor/)