### PR TITLE
chore: hide mqa score on org page when missing mqa data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24974,9 +24974,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/src/pages/organizations/pages/organization-page/index.tsx
+++ b/src/pages/organizations/pages/organization-page/index.tsx
@@ -325,7 +325,7 @@ const OrganizationPage: FC<Props> = ({
                   </StatisticsRegularSC.StatisticsRegular.Label>
                 </StatisticsRegular>
               </SC.Box>
-              {rating && (
+              {rating?.datasets?.quality && (
                 <SC.Box>
                   <StatisticsRegular to={`${url}/datasets`}>
                     <StatisticsRegularSC.StatisticsRegular.Label>


### PR DESCRIPTION
Må sannsynligvis jobbe en del med hele mqa-løpet før vi kan fikse dette på en god måte, har oppretta dette for å ta tak i problemet senere: https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/1059

Så på kort sikt bare deaktiverer vi