### PR TITLE
fix: bump serialize-javascript to 7.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21376,14 +21376,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -23083,11 +23075,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "json5": "2.2.3",
     "axios": "^1.12.0",
     "semver": "^7.6.2",
-    "serialize-javascript": "^6.0.2",
+    "serialize-javascript": "^7.0.3",
     "puppeteer": "22.12.0",
     "micromatch": "^4.0.8"
   },


### PR DESCRIPTION
# Summary

- Upgrades `serialize-javascript` override from `^6.0.2` to `^7.0.3` to fix GHSA-5c6j-r48x-rmvq (RCE, CVSS 8.1)
- Resolves 6 high-severity vulnerabilities across `copy-webpack-plugin`, `oidc-client`, and `terser-webpack-plugin`