### PR TITLE
fix: bump uuid to 11.1.1 via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25720,12 +25720,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "puppeteer": "22.12.0",
     "micromatch": "^4.0.8",
     "@tootallnate/once": "^2.0.1",
+    "uuid": "^11.1.1",
     "@ardatan/relay-compiler": {
       "immutable": "3.8.3"
     }


### PR DESCRIPTION
# Summary

- Adds `"uuid": "^11.1.1"` to `overrides` in package.json to fix Dependabot alert #180 (GHSA-w5hq-g745-h8pq, moderate)
- Vulnerability was transitive: webpack-dev-server → sockjs@0.3.24 → uuid@8.3.2
- sockjs only uses `uuid.v4`, which uuid 11 still exports — verified safe